### PR TITLE
fix: exception handling for `pNode null` case

### DIFF
--- a/components/base/src/util.ts
+++ b/components/base/src/util.ts
@@ -68,7 +68,9 @@ export function clearTemplate(_this: any, templateNames?: string[], index?: any)
                         if(rt._view){
                             let pNode: any = rt._view.renderer.parentNode(rt.rootNodes[0]);
                             for (let m: number = 0; m < rt.rootNodes.length; m++) {
-                                pNode.appendChild(rt.rootNodes[m]);
+                                if (pNode) {
+                                    pNode.appendChild(rt.rootNodes[m]);
+                                }
                             }
                         }
                         rt.destroy();


### PR DESCRIPTION
When we try to edit one node and delete it, it throws error. Adding this exception handling will resolve this problem.

Please review this PR.

Thank you.